### PR TITLE
deprecate commandf

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,6 @@ Command::Runner - run external commands and Perl code refs
     );
     my $res = $cmd->run;
 
-    my $untar = Command::Runner->new;
-    $untar->commandf(
-      '%q -dc %q | %q tf -',
-      'C:\\Program Files (x86)\\GnuWin32\\bin\\gzip.EXE',
-      'File-ShareDir-Install-0.13.tar.gz'
-      'C:\\Program Files (x86)\\GnuWin32\\bin\\tar.EXE',
-    );
-    my $capture = $untar->run->{stdout};
-
 # DESCRIPTION
 
 Command::Runner runs external commands and Perl code refs
@@ -39,21 +30,6 @@ A constructor, which takes:
 
     an array of external commands, a string of external programs, or a Perl code ref.
     If an array of external commands is specified, it is automatically quoted on Windows.
-
-- commandf
-
-    a command string by `sprintf`-like syntax.
-    You can use positional formatting together with a conversion `%q` (with quoting).
-
-    Here is an example:
-
-        my $cmd = Command::Runner->new(
-          commandf => [ '%q %q >> %q', '/path/to/cat', 'foo bar.txt', 'out.txt' ],
-        );
-
-        # or, you can set it separately
-        my $cmd = Command::Runner->new;
-        $cmd->commandf('%q %q >> %q', '/path/to/cat', 'foo bar.txt', 'out.txt');
 
 - timeout
 

--- a/lib/Command/Runner/Format.pm
+++ b/lib/Command/Runner/Format.pm
@@ -18,6 +18,9 @@ my $regex = qr/
              )/x;
 
 sub commandf {
+    if (!$ENV{PERL_COMMAND_RUNNER_SUPPRESS_WARNINGS}) {
+        warn "Command::Runner::Format::commandf is deprecated; will be removed in the future version of Command-Runner distribution";
+    }
     my ($format, @args) = @_;
     my $i = 0;
     $format =~ s{$regex}{

--- a/t/01_basic.t
+++ b/t/01_basic.t
@@ -62,32 +62,6 @@ subtest array_redirect => sub {
     ok !$res->{timeout};
 };
 
-subtest string => sub {
-    my ($stdout, $stderr) = ("", "");
-    my $res = Command::Runner->new
-        ->commandf("%q -e %q", $^X, "warn 1; print 2; exit 3")
-        ->stdout(sub { $stdout .= $_[0] })
-        ->stderr(sub { $stderr .= $_[0] })
-        ->run;
-    is $res->{result} >> 8, 3;
-    is $stdout, "2";
-    is $stderr, "1 at -e line 1.";
-    ok !$res->{timeout};
-};
-
-subtest string_redirect => sub {
-    my ($stdout, $stderr) = ("", "");
-    my $res = Command::Runner->new
-        ->commandf("%q -e %q", $^X, "warn 1; print 2; exit 3")
-        ->redirect(1)
-        ->stdout(sub { $stdout .= $_[0] })
-        ->run;
-    is $res->{result} >> 8, 3;
-    is $stdout, "1 at -e line 1.2";
-    is $stderr, "";
-    ok !$res->{timeout};
-};
-
 my %SIGNAL = do {
     my @sig = split /\s+/, $Config{sig_name} || "";
     map { ($_, $sig[$_]) } 0...$#sig;

--- a/t/02_basic.t
+++ b/t/02_basic.t
@@ -69,18 +69,4 @@ subtest timeout => sub {
     }
 };
 
-subtest pipe => sub {
-    my (@stdout, @stderr);
-    my $cmd = Command::Runner->new(
-        commandf => [ '%q -le %q | %q -nle %q', $^X, 'print "2";', $^X, 'print' ],
-        stdout => sub { push @stdout, @_ },
-        stderr => sub { push @stderr, @_ },
-    );
-    my $res = $cmd->run;
-    is $res->{result}, 0;
-    is @stdout, 1;
-    is $stdout[0], 2;
-    is @stderr, 0;
-};
-
 done_testing;


### PR DESCRIPTION
I added `commandf` because I thought it was useful.
But, in fact, I don't use `commandf` anymore.

Let's deprecate it.